### PR TITLE
Use https://wpackagist.org in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://wpackagist.org"
+            "url": "https://wpackagist.org"
         },
         {
             "type": "package",


### PR DESCRIPTION
[Composer\Downloader\TransportException] Your configuration does not allow connections to http://wpackagist.org/packages.json. See https://getcomposer.org/doc/06-config.md#secure-http for details.

To fix this we should use https://wpackagist.org rather than http://wpackagist.org.